### PR TITLE
Installer: If not bash, execute the script in bash, otherwise exit

### DIFF
--- a/AffinityScripts/AffinityLinuxInstaller.sh
+++ b/AffinityScripts/AffinityLinuxInstaller.sh
@@ -14,8 +14,14 @@ fi
 
 # Ensure script is being run with bash
 if [ -z "$BASH_VERSION" ]; then
-    echo "This script must be run with bash"
-    exit 1
+    echo "Running script in bash"
+    # Check bash existence
+    if command -v bash >/dev/null 2>&1; then
+        exec bash "$0" "$@"
+    else
+        echo "This script must be run with bash" >&2
+        exit 1
+    fi
 fi
 
 # ==========================================


### PR DESCRIPTION
Minimal change to the installer.sh,

If the script isn't running in bash, you can automatically execute the script in bash (if bash is on the system), otherwise exit. Saves the need to re-launch the script properly, and users on zsh (for example) can run the script normally without a second thought.