### PR TITLE
missing fi statement

### DIFF
--- a/AffinityScripts/AffinityLinuxInstaller.sh
+++ b/AffinityScripts/AffinityLinuxInstaller.sh
@@ -638,6 +638,7 @@ setup_wine() {
             print_warning "Could not find vkd3d-proton directory after extraction"
         fi
     fi
+    fi
     
     # Setup Wine
     print_header "Wine Configuration"


### PR DESCRIPTION
Running ./AffinityLinuxInstaller.sh after git clone gives the following error `
/path/to/AffinityOnLinux/AffinityScripts/AffinityLinuxInstaller.sh: line 695: syntax error near unexpected token `}' /path/to/AffinityOnLinux/AffinityScripts/AffinityLinuxInstaller.sh: line 695: `}' `

The if statement starting at line 553 that checks for AMD GPU (if [ "$has_amd_gpu" = true ]; then) is missing its closing fi statement after the else block ends at line 640.