### PR TITLE
Implement GPU detection and selection in installer for multi-gpu users

### DIFF
--- a/AffinityScripts/AffinityLinuxInstaller.sh
+++ b/AffinityScripts/AffinityLinuxInstaller.sh
@@ -848,27 +848,27 @@ setup_wine() {
     print_progress ".NET 4.8 installation attempted"
     
     print_step "Installing Windows core fonts..."
-    WINEPREFIX="$directory" winetricks --unattended --force --no-isolate --optout corefonts >/dev/null 2>&1 || true
+    WINEPREFIX="$directory" winetricks --unattended --force --no-isolate --optout corefonts || true
     print_progress "Core fonts installation attempted"
     
     print_step "Installing Visual C++ Redistributables 2022..."
-    WINEPREFIX="$directory" winetricks --unattended --force --no-isolate --optout vcrun2022 >/dev/null 2>&1 || true
+    WINEPREFIX="$directory" winetricks --unattended --force --no-isolate --optout vcrun2022 || true
     print_progress "VC++ 2022 installation attempted"
     
     print_step "Installing MSXML 3.0..."
-    WINEPREFIX="$directory" winetricks --unattended --force --no-isolate --optout msxml3 >/dev/null 2>&1 || true
+    WINEPREFIX="$directory" winetricks --unattended --force --no-isolate --optout msxml3 || true
     print_progress "MSXML 3.0 installation attempted"
     
     print_step "Installing MSXML 6.0..."
-    WINEPREFIX="$directory" winetricks --unattended --force --no-isolate --optout msxml6 >/dev/null 2>&1 || true
+    WINEPREFIX="$directory" winetricks --unattended --force --no-isolate --optout msxml6 || true
     print_progress "MSXML 6.0 installation attempted"
     
     print_step "Installing Tahoma font..."
-    WINEPREFIX="$directory" winetricks --unattended --force --no-isolate --optout tahoma >/dev/null 2>&1 || true
+    WINEPREFIX="$directory" winetricks --unattended --force --no-isolate --optout tahoma || true
     print_progress "Tahoma font installation attempted"
     
     print_step "Configuring Wine to use Vulkan renderer..."
-    WINEPREFIX="$directory" winetricks --unattended --force --no-isolate --optout renderer=vulkan >/dev/null 2>&1 || true
+    WINEPREFIX="$directory" winetricks --unattended --force --no-isolate --optout renderer=vulkan || true
     print_success "Wine configured with Vulkan renderer"
     
     print_info "Note: The above installations may take several minutes. Errors are normal if components are already installed."


### PR DESCRIPTION
Added GPU detection and selection functionality to the installer script, allowing users to choose between available GPUs for optimal performance AND/OR integrated graphics use cases. 

Removed output suppression (`>/dev/null 2>&1`) during installation to improve troubleshooting.

///

Was having an issue where the `./install.py` GUI was detecting my laptops Integrated graphics as opposed to my nvidia gpu. This I believe lead to incorrect installation of dependencies and software. Once implemented, the .net installations hung so I fixed that. 

`rm rf` the .`AffinityLinux` folder and started the `./AffinityLinuxInstaller.sh` script, selected the correct GPU, which then correctly installed everything. Also installed Affinity, and it finally launched for the first time without any errors. Affinity startup logo is blacked out but that may just be my issue.

Complete install was used by running just the `./AffinityLinuxInstaller.sh`




Laptop Specs:
System:
  Kernel: 6.17.9-300.fc43.x86_64 arch: x86_64 bits: 64 compiler: gcc v: 15.2.1
  Desktop: GNOME v: 49.2 Distro: Fedora Linux 43 (Workstation Edition)

CPU:
  Info: 6-core model: Intel Core i7-10750H bits: 64 type: MT MCP
    arch: Comet Lake rev: 2 cache: L1: 384 KiB L2: 1.5 MiB L3: 12 MiB
  Speed (MHz): avg: 3601 min/max: 800/5000 cores: 1: 3601 2: 3601 3: 3601
    4: 3601 5: 3601 6: 3601 7: 3601 8: 3601 9: 3601 10: 3601 11: 3601 12: 3601
    bogomips: 62399